### PR TITLE
Fix package.json: repository must be a URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jest-preset-typescript",
   "version": "1.2.0",
   "main": "jest-preset-typescript.js",
-  "repository": "git@github.com:DSchau/jest-preset-typescript.git",
+  "repository": "git://git@github.com:DSchau/jest-preset-typescript.git",
   "author": "Dustin Schau <dustin.schau@gmail.com> (https://dustinschau.com)",
   "license": "MIT",
   "files": [


### PR DESCRIPTION
Current value of `package.json` `repository` is not a URL, as has no protocol.

And [as specified in official docs, the `repository` attribute in `package.json` should be a URL](https://docs.npmjs.com/files/package.json). 

Chose `git` as protocol and updated URL